### PR TITLE
Notebook deployment

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -16,7 +16,7 @@ export BACKUP_CONFIGMAP_NAME := $(or $(BACKUP_CONFIGMAP_NAME), pfdm-patroni-back
 ##if
 ifeq ($(GIT_LOCAL_BRANCH),dev)
 define DEPLOY_FILE
-"dev_dc_latest.yaml"
+"custom-notebook-dc.yaml"
 endef
 define OC_USER_ID
 "1009370000"

--- a/openshift/custom-notebook-dc.yaml
+++ b/openshift/custom-notebook-dc.yaml
@@ -1,0 +1,207 @@
+kind: Template
+apiVersion: template.openshift.io/v1
+objects:
+  - apiVersion: v1
+    kind: Service
+    spec:
+      ports:
+        - name: 8080-tcp
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+        - name: 8081-tcp
+          port: 8081
+          protocol: TCP
+          targetPort: 8081
+      selector:
+        deploymentconfig: ${NAME}
+        app: ${NAME}
+    metadata:
+      name: ${NAME}
+      labels:
+        deploymentconfig: ${NAME}
+        app: ${NAME}
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      name: ${NAME}
+      labels:
+        deploymentconfig: ${NAME}
+        app.kubernetes.io/part-of: ${LABEL_NAME}
+        app: ${NAME}
+    spec:
+      triggers:
+        - type: "ConfigChange"
+      replicas: ${{MIN_REPLICAS}}
+      revisionHistoryLimit: 5
+      selector:
+        deploymentconfig: ${NAME},
+        app: ${NAME}
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            deploymentconfig: ${NAME}
+            app: ${NAME}
+        spec:
+          volumes:
+            - name: data,
+              persistentVolumeClaim: 
+                claimName: ${NAME}-data
+          initContainers: 
+            - name: setup-volume,
+              image: ${NOTEBOOK_IMAGE}
+              command: 
+              - setup-volume.sh
+              - /opt/app-root
+              - /mnt/app-root
+              resources:
+                limits:
+                  memory: 256Mi
+              volumeMounts:
+                - name: data
+                  mountPath: /mnt
+          containers:
+            - image: ${NOTEBOOK_IMAGE}
+              volumeMounts:
+                - name: data
+                  mountPath: /opt/app-root
+                  subpath: app-root
+              name: notebook
+              automountServiceAccountToken: false
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
+                - containerPort: 8081
+                  protocol: TCP
+              resources:
+                limits:
+                  cpu: ${CPU_LIMITS}
+                  memory: ${MEM_LIMITS}
+                requests:
+                  cpu: ${CPU_REQUESTS}
+                  memory: ${MEM_REQUESTS}
+              env:
+              - name: JUPYTER_NOTEBOOK_PASSWORD
+                value: "${NOTEBOOK_PASSWORD}"
+              - name: DB_PORT
+                value: "$(PFDM_PATRONI_MASTER_SERVICE_PORT)"
+              - name: DB_HOST
+                value: "$(PFDM_PATRONI_MASTER_SERVICE_HOST)"
+              - name: DB_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: pfdm-patroni-creds
+                    key: database-user
+              - name: DB_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: pfdm-patroni-creds
+                    key: database-password
+              - name: DB_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: pfdm-patroni-creds
+                    key: database-name 
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    spec:
+      host: ''
+      port:
+        targetPort: 8080-tcp
+      to:
+        kind: Service
+        name: ${NAME}
+        weight: 100
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+    metadata:
+      name: ${NAME}
+      labels:
+        deploymentconfig: ${NAME}
+        app: ${NAME}
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata: 
+      name: ${NAME}-data,
+      labels:
+        app: ${NAME}
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: ${VOLUME_SIZE}
+  - apiVersion: autoscaling.k8s.io/v1
+    kind: VerticalPodAutoscaler
+    metadata:
+      name: ${NAME}
+      labels:
+        deploymentconfig: ${NAME}
+    spec:
+      targetRef:
+        kind: DeploymentConfig
+        name: ${NAME}
+        apiVersion: apps.openshift.io/v1
+      updatePolicy:
+        updateMode: "Recreate"
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: db-allow-internal
+      spec:
+        podSelector:
+          matchLabels:
+            cluster-name: ${PATRONI_NAME}
+        ingress:
+          - from:
+            - podSelector: {}
+        policyTypes:
+          - Ingress     
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: ${NAME}-allow-external
+      spec:
+        podSelector:
+          matchLabels:
+            deploymentconfig: ${NAME}
+        ingress:
+          - ports:
+            - protocol: TCP
+              port: 8080
+            - protocol: TCP
+              port: 8081
+        policyTypes:
+          - Ingress
+parameters:
+  - name: NAME
+    value: custom-notebook
+    required: true
+  - name: LABEL_NAME
+    required: true
+  - name: CPU_REQUESTS
+    required: true
+  - name: CPU_LIMITS
+    required: true
+  - name: MEM_REQUESTS
+    required: true
+  - name: MEM_LIMITS
+    required: true
+  - name: MIN_REPLICAS
+    required: true
+  - name: PATRONI_NAME
+    value: pfdm-patroni
+    required: true
+  - name: VOLUME_SIZE
+    required: true
+  - name: NOTEBOOK_IMAGE
+    value: quay.io/jupyteronopenshift/s2i-minimal-notebook-py36:2.5.1
+    required: true
+  - name: NOTEBOOK_INTERFACE
+    value: lab
+  - name: NOTEBOOK_PASSWORD
+    from: "[a-f0-9]{32}"
+    generate: expression      

--- a/openshift/dev.env
+++ b/openshift/dev.env
@@ -1,5 +1,5 @@
 # params
-NAME="pfdm"
+NAME="custom-notebook"
 NAMESPACE="caeb60-dev"
 OC_USER_ID="1017860000"
 BUILD_NAMESPACE="caeb60-tools"
@@ -20,3 +20,4 @@ MIN_REPLICAS="1"
 MAX_REPLICAS="2"
 LABEL_NAME="PFDM"
 VAULT_ENV="secrets.env"
+VOLUME_SIZE="1Gi"

--- a/openshift/dev_dc_latest.yaml
+++ b/openshift/dev_dc_latest.yaml
@@ -20,14 +20,6 @@ objects:
       name: ${NAME}
       labels:
         deploymentconfig: ${NAME}
-  - apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: ${NAME}
-      labels:
-        deploymentconfig: ${NAME}
-    data:
-      jupyter_server_config.py: "import os\n\npassword = os.environ.get('JUPYTER_NOTEBOOK_PASSWORD')\n\nif password:\n    from jupyter_server.auth import passwd\n    c.ServerApp.password = passwd(password)\n    del password\n    del os.environ['JUPYTER_NOTEBOOK_PASSWORD']\n\nimage_config_file = '/home/jovyan/.jupyter/jupyter_server_config.py'\n\nif os.path.exists(image_config_file):\n    with open(image_config_file) as fp:\n        exec(compile(fp.read(), image_config_file, 'exec'), globals())\n    "
   - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig
     metadata:
@@ -64,23 +56,14 @@ objects:
             - name: site-data-volume
               configMap:
                 name: subpath-env
-            - name: configs
-              configMap:
-                name: "${NAME}"
           containers:
-            - image: "${NOTEBOOK_IMAGE}"
+            - image: >-
+                image-registry.openshift-image-registry.svc:5000/${BUILD_NAMESPACE}/${NAME}
               volumeMounts:
                 - name: site-data-volume
                   mountPath: /var/site_data
-                - mountPath: "/etc/jupyter/openshift"
-                  name: configs
               imagePullPolicy: Always
               name: ${NAME}
-              command:
-              - start-notebook.py
-              - "--config=/etc/jupyter/openshift/jupyter_server_config.py"
-              - "--no-browser"
-              - "--ip=0.0.0.0"
               ports:
                 - containerPort: 8080
                   protocol: TCP
@@ -108,27 +91,6 @@ objects:
               env:
               - name: "ENV_ARG"
                 value: "hi there"
-              - name: JUPYTER_NOTEBOOK_PASSWORD
-                value: "${NOTEBOOK_PASSWORD}"
-              - name: DB_PORT
-                value: "$(PFDM_PATRONI_MASTER_SERVICE_PORT)"
-              - name: DB_HOST
-                value: "$(PFDM_PATRONI_MASTER_SERVICE_HOST)"
-              - name: DB_USER
-                valueFrom:
-                  secretKeyRef:
-                    name: pfdm-patroni-creds
-                    key: database-user
-              - name: DB_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: pfdm-patroni-creds
-                    key: database-password
-              - name: DB_NAME
-                valueFrom:
-                  secretKeyRef:
-                    name: pfdm-patroni-creds
-                    key: database-name 
   - apiVersion: route.openshift.io/v1
     kind: Route
     spec:
@@ -250,9 +212,3 @@ parameters:
     required: false
   - name: BUILD_MEM_LIMITS
     required: false
-  - name: NOTEBOOK_IMAGE
-    value: docker.io/jupyter/scipy-notebook:latest
-    required: true
-  - name: NOTEBOOK_PASSWORD
-    from: "[a-f0-9]{32}"
-    generate: expression

--- a/openshift/dev_dc_latest.yaml
+++ b/openshift/dev_dc_latest.yaml
@@ -20,6 +20,14 @@ objects:
       name: ${NAME}
       labels:
         deploymentconfig: ${NAME}
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ${NAME}
+      labels:
+        deploymentconfig: ${NAME}
+    data:
+      jupyter_server_config.py: "import os\n\npassword = os.environ.get('JUPYTER_NOTEBOOK_PASSWORD')\n\nif password:\n    from jupyter_server.auth import passwd\n    c.ServerApp.password = passwd(password)\n    del password\n    del os.environ['JUPYTER_NOTEBOOK_PASSWORD']\n\nimage_config_file = '/home/jovyan/.jupyter/jupyter_server_config.py'\n\nif os.path.exists(image_config_file):\n    with open(image_config_file) as fp:\n        exec(compile(fp.read(), image_config_file, 'exec'), globals())\n    "
   - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig
     metadata:
@@ -57,13 +65,19 @@ objects:
               configMap:
                 name: subpath-env
           containers:
-            - image: >-
-                image-registry.openshift-image-registry.svc:5000/${BUILD_NAMESPACE}/${NAME}
+            - image: "${NOTEBOOK_IMAGE}"
               volumeMounts:
                 - name: site-data-volume
                   mountPath: /var/site_data
+                - mountPath: "/etc/jupyter/openshift"
+                  name: configs
               imagePullPolicy: Always
               name: ${NAME}
+              command:
+              - start-notebook.py
+              - "--config=/etc/jupyter/openshift/jupyter_server_config.py"
+              - "--no-browser"
+              - "--ip=0.0.0.0"
               ports:
                 - containerPort: 8080
                   protocol: TCP
@@ -91,6 +105,31 @@ objects:
               env:
               - name: "ENV_ARG"
                 value: "hi there"
+              - name: JUPYTER_NOTEBOOK_PASSWORD
+                value: "${NOTEBOOK_PASSWORD}"
+              - name: DB_PORT
+                value: "$(PFDM_PATRONI_MASTER_SERVICE_PORT)"
+              - name: DB_HOST
+                value: "$(PFDM_PATRONI_MASTER_SERVICE_HOST)"
+              - name: DB_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: pfdm-patroni-creds
+                    key: database-user
+              - name: DB_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: pfdm-patroni-creds
+                    key: database-password
+              - name: DB_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: pfdm-patroni-creds
+                    key: database-name
+              volumes:
+              - configMap:
+                  name: "${NAME}"
+                  name: configs
   - apiVersion: route.openshift.io/v1
     kind: Route
     spec:
@@ -156,6 +195,8 @@ objects:
         ingress:
           - ports:
             - protocol: TCP
+              port: 8888
+            - protocol: TCP
               port: 8080
             - protocol: TCP
               port: 80
@@ -212,3 +253,9 @@ parameters:
     required: false
   - name: BUILD_MEM_LIMITS
     required: false
+  - name: NOTEBOOK_IMAGE
+    value: docker.io/jupyter/scipy-notebook:latest
+    required: true
+  - name: NOTEBOOK_PASSWORD
+    from: "[a-f0-9]{32}"
+    generate: expression

--- a/openshift/dev_dc_latest.yaml
+++ b/openshift/dev_dc_latest.yaml
@@ -64,6 +64,9 @@ objects:
             - name: site-data-volume
               configMap:
                 name: subpath-env
+            - name: configs
+              configMap:
+                name: "${NAME}"
           containers:
             - image: "${NOTEBOOK_IMAGE}"
               volumeMounts:
@@ -125,11 +128,7 @@ objects:
                 valueFrom:
                   secretKeyRef:
                     name: pfdm-patroni-creds
-                    key: database-name
-              volumes:
-              - configMap:
-                  name: "${NAME}"
-                  name: configs
+                    key: database-name 
   - apiVersion: route.openshift.io/v1
     kind: Route
     spec:
@@ -194,8 +193,6 @@ objects:
             deploymentconfig: ${NAME}
         ingress:
           - ports:
-            - protocol: TCP
-              port: 8888
             - protocol: TCP
               port: 8080
             - protocol: TCP

--- a/openshift/patroni-deploy.yaml
+++ b/openshift/patroni-deploy.yaml
@@ -166,12 +166,12 @@ objects:
                 storage: ${PVC_SIZE}
 parameters:
   - name: PATRONI_NAME
-    value: usp-patroni
+    value: pfdm-patroni
   - name: LABEL_NAME
     required: true
     description: some desc for this component
   - name: PROJECT
-    value: usp
+    value: pfdm
   - name: REPLICAS
     description: |
       The number of StatefulSet replicas to use.
@@ -205,7 +205,7 @@ parameters:
   - name: IMAGE_STREAM_TAG
     description: |
       Patroni ImageTag
-    value: usp-patroni:12.4-latest
+    value: pfdm-patroni:12.4-latest
   - name: PVC_SIZE
     description:
       The size of the persistent volume to create.


### PR DESCRIPTION
Added a template for a custom Jupyter notebook deployment with the necessary service, route, pvc, etc. 
Makefile is also updated to call the custom notebook dc instead of the previous pfdm dc in dev_latest_dc.yaml. This could be removed, but I've left it in the repo for the moment just in case, although it won't be built as part of the deploy-web action anymore.

Currently the deployment is using the minimal-notebook-py36 image of Jupyter notebook to confirm the template/pipeline works well, but this will be replaced by adding an s2i version of the image based on python 3.8 instead.