### PR TITLE
Notebook deployment

### DIFF
--- a/openshift/custom-notebook-dc.yaml
+++ b/openshift/custom-notebook-dc.yaml
@@ -35,7 +35,7 @@ objects:
       replicas: ${{MIN_REPLICAS}}
       revisionHistoryLimit: 5
       selector:
-        deploymentconfig: ${NAME},
+        deploymentconfig: ${NAME}
         app: ${NAME}
       strategy:
         type: Recreate
@@ -46,11 +46,11 @@ objects:
             app: ${NAME}
         spec:
           volumes:
-            - name: data,
+            - name: data
               persistentVolumeClaim: 
                 claimName: ${NAME}-data
           initContainers: 
-            - name: setup-volume,
+            - name: setup-volume
               image: ${NOTEBOOK_IMAGE}
               command: 
               - setup-volume.sh
@@ -125,7 +125,7 @@ objects:
   - apiVersion: v1
     kind: PersistentVolumeClaim
     metadata: 
-      name: ${NAME}-data,
+      name: ${NAME}-data
       labels:
         app: ${NAME}
     spec:
@@ -159,7 +159,7 @@ objects:
           - from:
             - podSelector: {}
         policyTypes:
-          - Ingress     
+          - Ingress
   - apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:

--- a/openshift/dev.env
+++ b/openshift/dev.env
@@ -1,5 +1,5 @@
 # params
-NAME="pfdm"
+NAME="custom-notebook"
 NAMESPACE="caeb60-dev"
 OC_USER_ID="1017860000"
 BUILD_NAMESPACE="caeb60-tools"


### PR DESCRIPTION
Fixed extra commas/spaces that were causing deployment to fail and updated name to 'custom-notebook' to match the current pvc to avoid deleting that data if possible.